### PR TITLE
used deposit nft asset values for each underlying farm's values in detail

### DIFF
--- a/src/sections/pools/farm/modals/positionDetail/PoolFarmPositionDetailSectionItem.tsx
+++ b/src/sections/pools/farm/modals/positionDetail/PoolFarmPositionDetailSectionItem.tsx
@@ -1,13 +1,13 @@
+import { PoolBase } from "@galacticcouncil/sdk"
+import { PalletLiquidityMiningYieldFarmEntry } from "@polkadot/types/lookup"
+import { DepositNftType } from "api/deposits"
+import { ReactComponent as ChevronRight } from "assets/icons/ChevronRight.svg"
 import { ModalMeta } from "components/Modal/Modal"
 import { useTranslation } from "react-i18next"
-import { AprFarm } from "utils/farms/apr"
-import { PoolBase } from "@galacticcouncil/sdk"
-import { ReactComponent as ChevronRight } from "assets/icons/ChevronRight.svg"
-import { PalletLiquidityMiningYieldFarmEntry } from "@polkadot/types/lookup"
-import { PoolFarmPosition } from "../../position/PoolFarmPosition"
 import { PoolFarmDetail } from "sections/pools/farm/detail/PoolFarmDetail"
 import { PoolFarmLoyaltyGraph } from "sections/pools/farm/loyaltyGraph/PoolFarmLoyaltyGraph"
-import { DepositNftType } from "api/deposits"
+import { AprFarm } from "utils/farms/apr"
+import { PoolFarmPosition } from "../../position/PoolFarmPosition"
 
 export function PoolFarmPositionDetailSectionItem(props: {
   farm: AprFarm
@@ -47,10 +47,11 @@ export function PoolFarmPositionDetailSectionItem(props: {
           />
         )}
 
-        {props.position && (
+        {props.position && props.depositNft && (
           <PoolFarmPosition
             pool={props.pool}
             farm={props.farm}
+            depositNft={props.depositNft}
             position={props.position}
           />
         )}

--- a/src/sections/pools/farm/position/PoolFarmPosition.tsx
+++ b/src/sections/pools/farm/position/PoolFarmPosition.tsx
@@ -1,21 +1,28 @@
-import { useTranslation } from "react-i18next"
-import { AprFarm } from "utils/farms/apr"
 import { PoolBase } from "@galacticcouncil/sdk"
+import { PalletLiquidityMiningYieldFarmEntry } from "@polkadot/types/lookup"
+import { DepositNftType } from "api/deposits"
 import { Row } from "components/Row/Row"
 import { Separator } from "components/Separator/Separator"
-import { PalletLiquidityMiningYieldFarmEntry } from "@polkadot/types/lookup"
-import { usePoolPosition } from "utils/farms/positions"
+import { useTranslation } from "react-i18next"
+import { usePoolSharesDeposit } from "sections/pools/pool/shares/deposit/PoolSharesDeposit.utils"
 import { useEnteredDate } from "utils/block"
+import { AprFarm } from "utils/farms/apr"
+import { usePositionMinedValue } from "utils/farms/positions"
 
 export function PoolFarmPosition(props: {
   pool: PoolBase
   farm: AprFarm
+  depositNft: DepositNftType
   position: PalletLiquidityMiningYieldFarmEntry
 }) {
   const { t } = useTranslation()
 
-  const { mined, rewardAsset, assetA, assetB } = usePoolPosition({
+  const { mined, rewardAsset } = usePositionMinedValue({
     position: props.position,
+    pool: props.pool,
+  })
+  const { assetA, assetB } = usePoolSharesDeposit({
+    depositNft: props.depositNft,
     pool: props.pool,
   })
   const enteredDate = useEnteredDate(props.position.enteredAt.toBigNumber())


### PR DESCRIPTION
- Fixes #357 
- Asset values in farm detail are now displayed same as the entire farming position asset values, since the farming position shares are redistributed to other farms within that position 